### PR TITLE
Update to Go 1.8 and add a program-global "context" object

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.8
 
 RUN go get -d -v \
 		github.com/google/go-github/github \


### PR DESCRIPTION
This context stuff is to account for https://github.com/google/go-github/pull/529.